### PR TITLE
Fix for "GF_PATHS_DATA='/var/lib/grafana' is not writable"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# intellij
+.idea
+*.iml

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -24,4 +24,4 @@ grafana:
     - ${PWD}/provisioning:/grafana-conf
   env_file:
     - .env
-  user: "104"
+  user: "472"


### PR DESCRIPTION
/var/lib/grafana is only writable as data directory when grafana starts as user 472.

-> fixes " GF_PATHS_DATA='/var/lib/grafana' is not writable" which causes grafana to resist starting up